### PR TITLE
🍁 Performance bump on load test + stdTTL config added 

### DIFF
--- a/src/config/cacheConfig.js
+++ b/src/config/cacheConfig.js
@@ -11,9 +11,14 @@
  
  * maxKeys: To configure a max cache limit for an instance. Default is -1 (~1mil key limit).
             Accepts numeric data (>0). Setting maxKeys will add a cache limit to the instance.
+
+ * stdTTL: To configure a default ttl with every key value pair saved to the cache instance.
+           Accepts numeric data in ms (>0). Setting stdTTL, will overwrite default ttl = 0 to stdTTL value.
+           stdTTL value of 0 implies ttl is infinite and the key-value will never expire from cache.
 * */
 
 module.exports = cacheConfig = {
     forceString: true,
     maxKeys: -1,
+    stdTTL: 0
 }

--- a/src/worker/worker.js
+++ b/src/worker/worker.js
@@ -4,7 +4,7 @@
  * *****************************************
 */
 
-const { parentPort, isMainThread } = require('worker_threads');
+const { parentPort, isMainThread, threadId } = require('worker_threads');
 // Listen for most recent cache context from the Main Thread.
 if (!isMainThread) {
     parentPort.on("message", ({ cache, logger }) => {
@@ -17,7 +17,7 @@ if (!isMainThread) {
                 }
             }
         } catch (error) {
-            //TODO
+            console.error(`Exception with nodecache.js::worker (${threadId})  ${error.message}`)
         }
     })
 }


### PR DESCRIPTION
**1. Issue Reference #21**
**Updated benchmark score for sample data**
```shell
🍁 Load Test on NodeCahe::set()
┌─────────┬───────┬─────────┐
│ (index) │ item  │ time_ms │
├─────────┼───────┼─────────┤
│    0    │ 1000  │   36    │
│    1    │ 20000 │   36    │
│    2    │ 80000 │   29    │
└─────────┴───────┴─────────┘
🍁 Load Test on NodeCahe::get()
┌─────────┬───────┬─────────┐
│ (index) │ item  │ time_ms │
├─────────┼───────┼─────────┤
│    0    │ 1000  │   38    │
│    1    │ 20000 │   38    │
│    2    │ 80000 │   31    │
└─────────┴───────┴─────────┘
Failed execution: 0
````
---
**2. stdTTL config for cache instance**
```js
let cache = new NodeCache({
stdTTL: 50000 // 50sec default ttl on all set() calls
})
```