### PR TITLE
🍁 Cache update for private data members + New Unit Test suite

### DIFF
--- a/src/nodecache.js
+++ b/src/nodecache.js
@@ -11,18 +11,14 @@ let cacheConfig = require("./config/cacheConfig")
 
 
 class NodeCache {
-    #logger;
+    #logger
+    #cache
+    #config
     constructor(options = {}) {
-        this.cache = {}
+        this.#cache = {}
+        this.#config = Object.assign({}, cacheConfig);
         this.#logger = new Logger({ ...options })
-
-        let { forceString, maxKeys, stdTTL, valueOnly } = options
-        cacheConfig.valueOnly = valueOnly !== undefined && typeof valueOnly === "boolean" ? valueOnly : cacheConfig.valueOnly
-        cacheConfig.forceString = forceString !== undefined && typeof forceString === "boolean" ? forceString : cacheConfig.forceString
-        cacheConfig.maxKeys = maxKeys !== undefined && typeof maxKeys === "number" && maxKeys > 0 ? maxKeys : cacheConfig.maxKeys
-        cacheConfig.stdTTL = (stdTTL && typeof stdTTL === "number" && stdTTL >= 0) ? stdTTL : cacheConfig.stdTTL
-
-        this.config = { ...cacheConfig }
+        this.#setConfigurations(options);
 
         if (isMainThread) {
             this.worker = new Worker(path.join(__dirname, "/worker/worker.js"))
@@ -31,36 +27,55 @@ class NodeCache {
                 this.#logger.log(`${err.message}`, { type: "Worker Error" })
             })
 
-            this.worker.postMessage({ cache: this.cache })
+            this.worker.postMessage({ cache: this.#cache })
         }
 
         this.#logger.log(`nodeCache.js initialized`)
     }
 
+    #setConfigurations(options) {
+        if (options) {
+            let { forceString, maxKeys, stdTTL, valueOnly } = options;
+
+            if (valueOnly !== undefined && typeof valueOnly === "boolean")
+                this.#config.valueOnly = valueOnly
+            if (forceString !== undefined && typeof forceString === "boolean")
+                this.#config.forceString = forceString
+            if (maxKeys && typeof maxKeys === "number" && maxKeys > 0)
+                this.#config.maxKeys = maxKeys
+            if (stdTTL && typeof stdTTL === "number" && stdTTL >= 0)
+                this.#config.stdTTL = stdTTL
+        }
+    }
+
     getLogConfig() {
-        return this.#logger;
+        return this.#logger
+    }
+
+    getCacheConfig() {
+        return this.#config
     }
 
     get(key) {
-        const cacheItem = this.cache[key]
+        const cacheItem = this.#cache[key]
 
         if (!cacheItem) {
-            cacheConfig.cacheMiss += 1
+            this.#config.cacheMiss += 1
             this.#logger.log(`${CONSTANTS.ITEM_NOTFOUND} : ${key}`)
             return undefined
         }
-        if (cacheItem.ttl && cacheItem.ttl < Date.now()) {
-            cacheConfig.cacheMiss += 1
+        if (this.#config.stdTTL != 0 && cacheItem.ttl && cacheItem.ttl < Date.now()) {
+            this.#config.cacheMiss += 1
             // update the context of cache in the worker thread.
-            this.worker.postMessage({ cache: this.cache })
+            this.worker.postMessage({ cache: this.#cache })
             //passive ttl expire - fallback for env not supporting worker threads
             this.delete(key)
             this.#logger.log(`${CONSTANTS.ITEM_NOTFOUND} : ${key}`)
             return undefined
         }
 
-        cacheConfig.cacheHit += 1
-        if (cacheConfig.valueOnly) {
+        this.#config.cacheHit += 1
+        if (this.#config.valueOnly) {
             return cacheItem.value
         }
         return cacheItem
@@ -79,11 +94,11 @@ class NodeCache {
             return false
         }
 
-        if (cacheConfig.maxKeys > 0 && cacheConfig.maxKeys <= Object.keys(this.cache).length) {
+        if (this.#config.maxKeys > 0 && this.#config.maxKeys <= Object.keys(this.#cache).length) {
             throw new Error(CONSTANTS.MAX_CACHE_LIMIT)
         }
 
-        if (cacheConfig.forceString && typeof value !== "string") {
+        if (this.#config.forceString && typeof value !== "string") {
             value = JSON.stringify(value)
         }
 
@@ -91,10 +106,10 @@ class NodeCache {
             throw new Error(CONSTANTS.INVALID_TTL_TYPE)
         }
 
-        this.cache[key] = { value, ttl: ttl ? Date.now() + Math.abs(ttl) : Date.now() + cacheConfig.stdTTL }
-        cacheConfig.keyCount += 1
+        this.#cache[key] = { value, ttl: ttl ? Date.now() + Math.abs(ttl) : Date.now() + this.#config.stdTTL }
+        this.#config.keyCount += 1
         // update the context of cache in the worker thread.
-        // this.worker.postMessage({ cache: this.cache, logger: this.#logger, action: "set" })
+        // this.worker.postMessage({ cache: this.#cache, logger: this.#logger, action: "set" })
         return true
     }
 
@@ -118,7 +133,7 @@ class NodeCache {
             return [false]
         }
 
-        if (cacheConfig.maxKeys > 0 && cacheConfig.maxKeys <= values.length) {
+        if (this.#config.maxKeys > 0 && this.#config.maxKeys <= values.length) {
             throw new Error(CONSTANTS.MAX_CACHE_LIMIT)
         }
 
@@ -135,7 +150,7 @@ class NodeCache {
         if (!key || (!["string", "number"].includes(typeof key))) {
             throw new Error(CONSTANTS.INVALID_KEY_TYPE)
         }
-        let item = this.cache[key]
+        let item = this.#cache[key]
         return item ? item.ttl : undefined
     }
 
@@ -148,11 +163,11 @@ class NodeCache {
             throw new Error(CONSTANTS.INVALID_TTL_TYPE)
         }
 
-        if (!this.cache[key])
+        if (!this.#cache[key])
             return false
 
         const newTTL = Date.now() + Math.abs(ttl)
-        this.cache[key].ttl = newTTL
+        this.#cache[key].ttl = newTTL
         return true
     }
 
@@ -160,12 +175,12 @@ class NodeCache {
         return new Promise((resolve, reject) => {
             try {
                 const now = Date.now()
-                for (const [key, cacheItem] of Object.entries(this.cache)) {
+                for (const [key, cacheItem] of Object.entries(this.#cache)) {
                     if (cacheItem.ttl && Number(cacheItem.ttl) < Number(now)) {
                         this.delete(key)
                     }
                 }
-                resolve(this.cache)
+                resolve(this.#cache)
             } catch (error) {
                 reject(new Error(`Refresh failed to update cache: ${error.message}`))
             }
@@ -174,7 +189,7 @@ class NodeCache {
     }
 
     global() {
-        const { cacheHit, cacheMiss, keyCount } = cacheConfig
+        const { cacheHit, cacheMiss, keyCount } = this.#config
         return {
             cacheHit,
             cacheMiss,
@@ -183,15 +198,13 @@ class NodeCache {
     }
 
     flush() {
-        cacheConfig.cacheHit = 0
-        cacheConfig.cacheMiss = 0
-        cacheConfig.keyCount = 0
-        this.cache = {}
+        this.#config = cacheConfig;
+        this.#cache = {}
     }
 
     delete(key) {
-        delete this.cache[key]
-        cacheConfig.keyCount -= 1
+        delete this.#cache[key]
+        this.#config.keyCount -= 1
     }
 
     _onWorkerMessage({ key }) {

--- a/test/nodecache.config.test.js
+++ b/test/nodecache.config.test.js
@@ -337,13 +337,13 @@ describe("NodeCache params for instance config", () => {
         })
 
         test("NodeCache instance with Logger::mode as none", () => {
-            expect(cache.logger.mode).toEqual("none")
+            expect(cache.getLogConfig().mode).toEqual("none")
         })
         test("NodeCache instance with Logger::type as Custom", () => {
-            expect(cache.logger.type).toEqual("Custom")
+            expect(cache.getLogConfig().type).toEqual("Custom")
         })
         test("NodeCache instance with Logger::path as none", () => {
-            expect(cache.logger.path).toEqual("none")
+            expect(cache.getLogConfig().path).toEqual("none")
         })
     })
 
@@ -360,13 +360,13 @@ describe("NodeCache params for instance config", () => {
             expect(cache).not.toBe(null)
         })
         test("NodeCache instance with Logger::mode as std", () => {
-            expect(cache.logger.mode).toEqual("std")
+            expect(cache.getLogConfig().mode).toEqual("std")
         })
         test("NodeCache instance with Logger::type as Custom", () => {
-            expect(cache.logger.type).toEqual("Custom")
+            expect(cache.getLogConfig().type).toEqual("Custom")
         })
         test("NodeCache instance with Logger::path as none", () => {
-            expect(cache.logger.path).toEqual("none")
+            expect(cache.getLogConfig().path).toEqual("none")
         })
     })
 
@@ -385,9 +385,9 @@ describe("NodeCache params for instance config", () => {
 
         test("When valid instance uses default params for logger", () => {
             expect(cache).not.toBe(null)
-            expect(cache.logger.mode).toEqual("none")
-            expect(cache.logger.type).toEqual("xyz")
-            expect(cache.logger.path).toEqual("none")
+            expect(cache.getLogConfig().mode).toEqual("none")
+            expect(cache.getLogConfig().type).toEqual("xyz")
+            expect(cache.getLogConfig().path).toEqual("none")
         })
     })
 })

--- a/test/nodecache.config.test.js
+++ b/test/nodecache.config.test.js
@@ -4,26 +4,38 @@ const NodeCache = require("../index")
 describe("NodeCache params for instance config", () => {
 
     describe("NodeCache params - all invalid", () => {
-
         let cache
         afterEach(() => {
             cache.close()
         })
-
-        test("When all config values are null ", () => {
+        test("When all config values are null", () => {
             cache = new NodeCache({
                 forceString: null,
                 stdTTL: null,
                 maxKeys: null,
+                valueOnly: null
             })
             cache.set(1, 12345)
-            expect(cache.cache[1]).toStrictEqual({
+            //since forceString will be enabled by default and valueOnly will be true by default.
+            expect(cache.get(1)).toStrictEqual(expect.any(String))
+            expect(cache.get(1)).toStrictEqual("12345")
+        })
+
+        test("When all config values are null with valueOnly disabled", () => {
+            cache = new NodeCache({
+                forceString: null,
+                stdTTL: null,
+                maxKeys: null,
+                valueOnly: false
+            })
+            cache.set(1, 12345)
+            expect(cache.get(1)).toStrictEqual({
                 value: expect.any(String), //since forceString will be enabled by default
                 ttl: expect.any(Number)
             })
 
-            expect(cache.cache[1]?.ttl).toBeLessThanOrEqual(Date.now())
-            expect(cache.cache[1]?.value).toStrictEqual("12345")
+            expect(cache.get(1)?.ttl).toBeLessThanOrEqual(Date.now())
+            expect(cache.get(1)?.value).toStrictEqual("12345")
         })
 
         test("When all config values are negative", () => {
@@ -32,15 +44,16 @@ describe("NodeCache params for instance config", () => {
                 forceString: -1,
                 stdTTL: -1,
                 maxKeys: -1,
+                valueOnly: false
             })
             cache.set(2, 678910)
-            expect(cache.cache[2]).toStrictEqual({
+            expect(cache.get(2)).toStrictEqual({
                 value: expect.any(String), //since forceString will be enabled by default
                 ttl: expect.any(Number)
             })
 
-            expect(cache.cache[2]?.ttl).toBeLessThanOrEqual(Date.now())
-            expect(cache.cache[2]?.value).toStrictEqual("678910")
+            expect(cache.get(2)?.ttl).toBeLessThanOrEqual(Date.now())
+            expect(cache.get(2)?.value).toStrictEqual("678910")
             expect(cache.setM([
                 { key: "kx", value: 1 },
                 { key: "ky", value: 2, ttl: 60 * 60 * 1000 },
@@ -56,9 +69,9 @@ describe("NodeCache params for instance config", () => {
 
         test("When no stdTTL value is configured", () => {
             try {
-                cache = new NodeCache()
+                cache = new NodeCache({ valueOnly: false })
                 cache.set("no-std-ttl", "test-value")
-                expect(cache.cache["no-std-ttl"]).toStrictEqual({
+                expect(cache.get("no-std-ttl")).toStrictEqual({
                     value: expect.any(String),
                     ttl: expect.any(Number)
                 })
@@ -70,20 +83,21 @@ describe("NodeCache params for instance config", () => {
         test("When valid stdTTL of 100ms is configured for all the NodeCache::set() calls", () => {
             try {
                 cache = new NodeCache({
-                    stdTTL: 100
+                    stdTTL: 100,
+                    valueOnly: false
                 })
 
                 cache.set("std-100", "test-value")
-                expect(cache.cache["std-100"]).toStrictEqual({
+                expect(cache.get("std-100")).toStrictEqual({
                     value: expect.any(String),
                     ttl: expect.any(Number)
                 })
                 setTimeout(() => {
                     cache.get("std-100")
-                    expect(cache.cache["std-100"]).toBeUndefined()
+                    expect(cache.get("std-100")).toBeUndefined()
                 }, 150)
 
-                expect(cache.cache["std-100"]?.ttl).toBeGreaterThanOrEqual(Date.now())
+                expect(cache.get("std-100")?.ttl).toBeGreaterThanOrEqual(Date.now())
             } catch (error) {
                 console.warn(error.message)
             }
@@ -91,84 +105,91 @@ describe("NodeCache params for instance config", () => {
 
         test("When valid, very large stdTTL value configured", () => {
             cache = new NodeCache({
-                stdTTL: 30 * 24 * 60 * 60 * 1000 // 30 days
+                stdTTL: 30 * 24 * 60 * 60 * 1000, // 30 days
+                valueOnly: false
             })
 
             cache.set("std-large", "test-value-largeStd")
-            expect(cache.cache["std-large"]).toStrictEqual({
+            expect(cache.get("std-large")).toStrictEqual({
                 value: expect.anything(),
                 ttl: expect.any(Number)
             })
-            expect(cache.cache["std-large"].ttl).toBeGreaterThanOrEqual(Date.now())
-            expect(cache.cache["std-large"].value).toStrictEqual("test-value-largeStd")
+            expect(cache.get("std-large").ttl).toBeGreaterThanOrEqual(Date.now())
+            expect(cache.get("std-large").value).toStrictEqual("test-value-largeStd")
         })
 
         test("When boolean stdTTL value is configured", () => {
             cache = new NodeCache({
-                stdTTL: true
+                stdTTL: true,
+                valueOnly: false
             })
             // expect the stdTTL to be 0 => Infinite.
             cache.set("std-boolean", "boolean-ttl-check")
-            expect(cache.cache["std-boolean"]).toStrictEqual({
+            expect(cache.get("std-boolean")).toStrictEqual({
                 value: expect.any(String),
                 ttl: expect.any(Number)
             })
-            expect(cache.cache["std-boolean"]?.ttl).toBeGreaterThanOrEqual(Date.now())
+            expect(cache.get("std-boolean")?.ttl).toBeGreaterThanOrEqual(Date.now())
         })
 
         test("When string stdTTL value is configured", () => {
             cache = new NodeCache({
-                stdTTL: "15000" // 15seconds
+                stdTTL: "15000", // 15seconds
+                valueOnly: false
             })
             // expect the stdTTL to be 0 => Infinite.
 
             cache.set("std-boolean", "string-ttl-check")
-            expect(cache.cache["std-boolean"]).toStrictEqual({
+            expect(cache.get("std-boolean")).toStrictEqual({
                 value: expect.any(String),
                 ttl: expect.any(Number)
             })
-            expect(cache.cache["std-boolean"]?.ttl).toBeGreaterThanOrEqual(Date.now())
+            expect(cache.get("std-boolean")?.ttl).toBeGreaterThanOrEqual(Date.now())
         })
 
         test("When falsy (NaN) stdTTL value is configured", () => {
             cache = new NodeCache({
+                valueOnly: false,
                 stdTTL: NaN // falsy values: 0, false, null, undefined, NaN, ''
             })
             // expect the stdTTL to be 0 => Infinite.
             cache.set("std-falsy", "falsy-check")
-            expect(cache.cache["std-falsy"]).toStrictEqual({
+            expect(cache.get("std-falsy")).toStrictEqual({
                 value: expect.any(String),
                 ttl: expect.any(Number)
             })
-            expect(cache.cache["std-falsy"].ttl).toBeGreaterThanOrEqual(Date.now())
+            expect(cache.get("std-falsy")?.ttl).toBeLessThanOrEqual(Date.now())
         })
 
         test("When falsy (null) stdTTL value is configured", () => {
             cache = new NodeCache({
+                forceString: false,
+                valueOnly: false,
                 stdTTL: null
             })
             // expect the stdTTL to be 0 => Infinite.
             cache.set("std-falsy-2", "falsy-check-2")
-            expect(cache.cache["std-falsy-2"]).toStrictEqual({
+            expect(cache.get("std-falsy-2")).toStrictEqual({
                 value: expect.any(String),
                 ttl: expect.any(Number)
             })
-            expect(cache.cache["std-falsy-2"].ttl).toBeGreaterThanOrEqual(Date.now())
-            expect(cache.cache["std-falsy-2"].value).toStrictEqual("falsy-check-2")
+            expect(cache.get("std-falsy-2")?.ttl).toBeLessThanOrEqual(Date.now())
+            expect(cache.get("std-falsy-2")?.value).toStrictEqual("falsy-check-2")
         })
 
         test("When falsy (undefined) stdTTL value is configured", () => {
             cache = new NodeCache({
-                stdTTL: undefined
+                stdTTL: undefined,
+                valueOnly: false
             })
             // expect the stdTTL to be 0 => Infinite.
             cache.set("std-falsy-2", "falsy-check-2")
-            expect(cache.cache["std-falsy-2"]).toStrictEqual({
+            expect(cache.get("std-falsy-2")).toStrictEqual({
                 value: expect.any(String),
                 ttl: expect.any(Number)
             })
-            expect(cache.cache["std-falsy-2"].ttl).toBeGreaterThanOrEqual(Date.now())
-            expect(cache.cache["std-falsy-2"].value).toStrictEqual("falsy-check-2")
+            expect(cache.get("std-falsy-2")?.ttl).toBeLessThanOrEqual(Date.now())
+            expect(cache.get("std-falsy-2")?.value).toStrictEqual("falsy-check-2")
         })
     })
 
@@ -187,7 +208,7 @@ describe("NodeCache params for instance config", () => {
                 createAt: Date.now()
             })
 
-            let { value } = cache.cache["key1"]
+            const value = cache.get("key1")
 
             expect(value).not.toBeUndefined()
             expect(value).toEqual(expect.any(String)) // not an object anymore
@@ -203,7 +224,7 @@ describe("NodeCache params for instance config", () => {
                 createAt: Date.now()
             })
 
-            let { value } = cache.cache["key2"]
+            const value = cache.get("key2")
 
             expect(value).not.toBeUndefined()
             expect(value).toEqual(expect.any(Object))
@@ -226,7 +247,8 @@ describe("NodeCache params for instance config", () => {
             }
 
             expect(flag).toBeTruthy()
-            expect(cache.cache[6]).not.toBeUndefined()
+            expect(cache.get(6)).not.toBeUndefined()
+            cache.close()
         })
 
         test("When maxKeys set to 5, limit imposed on cache", () => {
@@ -240,15 +262,27 @@ describe("NodeCache params for instance config", () => {
                 }
             }).toThrow(Error)
 
-            expect(cache.cache[5]).not.toBeUndefined()
-            expect(cache.cache[6]).toBeUndefined()
+            expect(cache).toBeDefined()
+            const loggerConfigurations = cache.getLogConfig()
+            const configurations = cache.getCacheConfig()
+
+            expect(configurations).toBeDefined()
+            expect(configurations).toStrictEqual(expect.any(Object))
+
+            expect(loggerConfigurations).toBeDefined()
+            expect(loggerConfigurations).toStrictEqual(expect.any(Object))
+            expect(cache.get(6)).toBeUndefined()
+
+            cache.close()
         })
     })
     describe("NodeCache valueOnly configurations: Default (true) case", () => {
         let cache
         beforeEach(() => {
             cache = new NodeCache({
-                //    valueOnly: true // By default valueOnly is set to true -> backward compatibility with older npm versions.
+                forceString: false
+                // valueOnly: true 
+                // By default valueOnly is set to true -> backward compatibility with older npm versions.
             })
         })
         afterEach(() => {
@@ -256,7 +290,7 @@ describe("NodeCache params for instance config", () => {
         })
 
         test("When not valueOnly flag with the instance", () => {
-            expect(cache.config["valueOnly"]).toEqual(true)
+            expect(cache.getCacheConfig().valueOnly).toEqual(true)
         })
 
         test("When using Get() and Set() calls - true case", () => {
@@ -282,6 +316,8 @@ describe("NodeCache params for instance config", () => {
         let cache
         beforeEach(() => {
             cache = new NodeCache({
+                //forceString: true by default
+                forceString: false,
                 valueOnly: false
             })
         })
@@ -290,7 +326,7 @@ describe("NodeCache params for instance config", () => {
         })
 
         test("When not valueOnly flag with the instance", () => {
-            expect(cache.config["valueOnly"]).toEqual(false)
+            expect(cache.getCacheConfig().valueOnly).toEqual(false)
         })
 
         test("When using get() and set() calls - false case", () => {

--- a/test/nodecache.configsetup.test.js
+++ b/test/nodecache.configsetup.test.js
@@ -1,0 +1,151 @@
+const NodeCache = require("../index")
+
+describe("NodeCache.js Configuration Setup Suit", () => {
+    let cache;
+    afterEach(() => {
+        cache.close()
+    })
+
+    test("NodeCache.js with no configuration options to be defined", () => {
+        cache = new NodeCache();
+
+        expect(cache).toBeDefined()
+        expect(cache.getLogConfig()).toBeDefined()
+        expect(cache.getLogConfig()).toStrictEqual(expect.any(Object))
+
+        expect(cache.getCacheConfig()).toBeDefined()
+        expect(cache.getCacheConfig()).toStrictEqual({
+            forceString: true,
+            valueOnly: true,
+            maxKeys: -1,
+            stdTTL: 0,
+            cacheHit: 0,
+            cacheMiss: 0,
+            keyCount: 0,
+        })
+    })
+
+    test("NodeCache.js with explicit null configuration options to be defined", () => {
+        cache = new NodeCache({
+            forceString: null,
+            valueOnly: null,
+            maxKeys: null,
+            stdTTL: null
+        });
+
+        expect(cache).toBeDefined()
+        expect(cache.getLogConfig()).toBeDefined()
+        expect(cache.getLogConfig()).toStrictEqual(expect.any(Object))
+
+        expect(cache.getCacheConfig()).toBeDefined()
+        expect(cache.getCacheConfig()).toStrictEqual({
+            forceString: true,
+            valueOnly: true,
+            maxKeys: -1,
+            stdTTL: 0,
+            cacheHit: 0,
+            cacheMiss: 0,
+            keyCount: 0,
+        })
+    })
+
+    test("NodeCache.js with valueOnly false configuration options to be defined", () => {
+        cache = new NodeCache({
+            valueOnly: false
+        });
+
+        expect(cache).toBeDefined()
+        const loggerConfiguration = cache.getLogConfig()
+        const configuration = cache.getCacheConfig()
+
+        expect(loggerConfiguration).toBeDefined()
+        expect(loggerConfiguration).toStrictEqual(expect.any(Object))
+        expect(configuration).toStrictEqual(expect.any(Object))
+
+        expect(configuration).toBeDefined()
+        expect(configuration).toStrictEqual({
+            forceString: true,
+            valueOnly: false,
+            maxKeys: -1,
+            stdTTL: 0,
+            cacheHit: 0,
+            cacheMiss: 0,
+            keyCount: 0,
+        })
+
+        cache.set("config-1", 707301, 60 * 60 * 1000)
+        expect(cache.get("config-1")).toStrictEqual({
+            value: expect.any(String),
+            ttl: expect.any(Number)
+        })
+    })
+
+    test("NodeCache.js with forceString false configuration options to be defined", () => {
+        cache = new NodeCache({
+            forceString: false
+            //valueOnly: true by default
+        });
+
+        expect(cache).toBeDefined()
+        const loggerConfiguration = cache.getLogConfig()
+        const configuration = cache.getCacheConfig()
+
+        expect(loggerConfiguration).toBeDefined()
+        expect(loggerConfiguration).toStrictEqual(expect.any(Object))
+
+        expect(configuration).toBeDefined()
+        expect(configuration).toStrictEqual({
+            forceString: false,
+            valueOnly: true,
+            maxKeys: -1,
+            stdTTL: 0,
+            cacheHit: 0,
+            cacheMiss: 0,
+            keyCount: 0,
+        })
+        cache.set("config-1", 707301, 60 * 60 * 1000)
+        expect(cache.get("config-1")).toStrictEqual(707301)
+    })
+
+    test("NodeCache.js with all valid configuration options to be defined", () => {
+        cache = new NodeCache({
+            forceString: false,
+            valueOnly: false,
+            maxKeys: 3,
+            stdTTL: 2 * 60 * 60 * 1000
+        });
+
+        expect(cache).toBeDefined()
+        const loggerConfiguration = cache.getLogConfig()
+        const configuration = cache.getCacheConfig()
+
+        expect(loggerConfiguration).toBeDefined()
+        expect(loggerConfiguration).toStrictEqual(expect.any(Object))
+
+        expect(configuration).toBeDefined()
+        expect(configuration).toStrictEqual({
+            forceString: false,
+            valueOnly: false,
+            maxKeys: 3,
+            stdTTL: 2 * 60 * 60 * 1000,
+            cacheHit: 0,
+            cacheMiss: 0,
+            keyCount: 0,
+        })
+        cache.set("config-1", 707301)
+        expect(cache.get("config-1")).toStrictEqual({
+            value: 707301,
+            ttl: expect.any(Number)
+        })
+
+        cache.setM([
+            { key: 1, value: { data: 7073011 } },
+            { key: 2, value: { data: 7073012 } }
+        ])
+
+        expect(cache.get(1)).toStrictEqual({
+            value: { data: 7073011 },
+            ttl: expect.any(Number)
+        })
+    })
+})

--- a/test/nodecache.test.js
+++ b/test/nodecache.test.js
@@ -16,13 +16,13 @@ describe("NodeCache instance creation", () => {
         })
 
         test("NodeCache instance with default Logger::mode = none", () => {
-            expect(cache.logger.mode).toEqual("none")
+            expect(cache.getLogConfig().mode).toEqual("none")
         })
         test("NodeCache instance with Logger::type = info", () => {
-            expect(cache.logger.type).toEqual("info")
+            expect(cache.getLogConfig().type).toEqual("info")
         })
         test("NodeCache instance with Logger::path = none", () => {
-            expect(cache.logger.path).toEqual("none")
+            expect(cache.getLogConfig().path).toEqual("none")
         })
     })
 
@@ -239,5 +239,17 @@ describe("NodeCache public APIs", () => {
         expect(() => cache.setTTL(NaN, NaN)).toThrow(Error)
         expect(() => cache.setTTL("valid-key", undefined)).toThrow(Error)
         expect(() => cache.setTTL(undefined, undefined)).toThrow(Error)
+    })
+
+    test("NodeCache::getLogConfig call to validate logger object", () => {
+        const logConfig = cache.getLogConfig();
+        expect(logConfig).toBeDefined()
+        expect(logConfig).toStrictEqual(expect.any(Object))
+        expect(logConfig).toEqual({
+            formatOptions: expect.any(Object),
+            mode: expect.any(String),
+            type: expect.any(String),
+            path: expect.any(String),
+        })
     })
 })

--- a/test/nodecache.test.js
+++ b/test/nodecache.test.js
@@ -55,7 +55,7 @@ describe("NodeCache public APIs", () => {
         cache.getM([
             1, "2", "key"
         ])
-        // expect(cache.global()).toEqual({ cacheHit: 2, cacheMiss: 1, keyCount: 2 })
+        expect(cache.global()).toEqual({ cacheHit: 2, cacheMiss: 1, keyCount: 2 })
         cache.flush()
         expect(cache.global()).toEqual({ cacheHit: 0, cacheMiss: 0, keyCount: 0 })
     })
@@ -71,7 +71,7 @@ describe("NodeCache public APIs", () => {
     })
     test("NodeCache::get with valid key on cache hit", () => {
         cache.set("k1", 12345)
-        expect(cache.get("k1")).toEqual("12345") // with forceString true by default
+        expect(cache.get("k1")).toStrictEqual("12345") // with forceString true by default
     })
     test("NodeCache::get with invalid key", () => {
         expect(cache.get(null)).toBeUndefined()
@@ -242,7 +242,7 @@ describe("NodeCache public APIs", () => {
     })
 
     test("NodeCache::getLogConfig call to validate logger object", () => {
-        const logConfig = cache.getLogConfig();
+        const logConfig = cache.getLogConfig()
         expect(logConfig).toBeDefined()
         expect(logConfig).toStrictEqual(expect.any(Object))
         expect(logConfig).toEqual({


### PR DESCRIPTION
**Changelog**
1. Make all data members private.
2. Access to private cache map disabled. i.e ` cache.cache` is not allowed. The cache is only exposed via the getters and setters.
3. Updated Configuration setup code change. Cache.config is get only for an instance and it is only exposed via `getCacheConfig()` api.
4. Logger configurations are private and only exposed via `getLogConfig()` api.
5. Code refactor. Removed bad code and updated unit test cases.
